### PR TITLE
Got it working in a case that was returning null

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,14 @@ function getClientIp(req) {
             ipAddress = null;
         }
     }
+    
+    // final attempt to get IP address, via info object within request.
+    // if despite all this we do not find ip, then it returns null.
+    if (!ipAddress) {
+        if (typeof req.info !== 'undefined'){
+            ipAddress = req.info.remoteAddress || null;
+        }
+    }
 
     return ipAddress;
 }


### PR DESCRIPTION
Added one more location to check for the IP address: in the remoteAddress field of the req.info object. This succeeded in certain cases the module was previously returning null.

Careful null checks were done on req.info before attempting to use it, to prevent an error from being thrown - the info object appears to not always be present in the req object.

For some reason checking in the try-catch block failed to provide the IP. It only worked when done separately, just prior to the return. This suggests there may be a problem with that block in certain scenarios (it might be worth testing).