### PR TITLE
introduce a built-in default implementation for a connect-middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,19 @@ function getClientIp(req) {
 }
 
 /**
+ * Expose a default implemtation for a connect middleware
+ * 
+ * @options.attributeName - name of attribute to augment request object with
+ */
+getClientIp.mw = function(options) {
+    var attr = options.attributeName || "clientIp";
+    return function(req, res, next) {
+        req[attr] = requestIp.getClientIp(req); // on localhost > 127.0.0.1
+        next();
+    }
+};
+
+/**
  * Expose mode public functions
  */
 exports.getClientIp = getClientIp;

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ exports.mw = function(options) {
     if (!options) options = {};
     var attr = options.attributeName || "clientIp";
     return function(req, res, next) {
-        req[attr] = getClientIp(req); // on localhost > 127.0.0.1
+        req[attr] = getClientIp(req);
         next();
     }
 };

--- a/index.js
+++ b/index.js
@@ -95,19 +95,21 @@ function getClientIp(req) {
 }
 
 /**
+ * Expose mode public functions
+ */
+exports.getClientIp = getClientIp;
+
+
+/**
  * Expose a default implemtation for a connect middleware
  * 
  * @options.attributeName - name of attribute to augment request object with
  */
-getClientIp.mw = function(options) {
+exports.mw = function(options) {
+    if (!options) options = {};
     var attr = options.attributeName || "clientIp";
     return function(req, res, next) {
-        req[attr] = requestIp.getClientIp(req); // on localhost > 127.0.0.1
+        req[attr] = getClientIp(req); // on localhost > 127.0.0.1
         next();
     }
 };
-
-/**
- * Expose mode public functions
- */
-exports.getClientIp = getClientIp;

--- a/test/index.js
+++ b/test/index.js
@@ -228,8 +228,6 @@ test('req.connection.remoteAddress', function(t) {
 
 test('request-ip.mw -', function(t) {
     t.plan(2);
-
-console.log(typeof requestIp.mw)
     
     t.equal(typeof requestIp.mw, 'function', 'requestIp.mw - should be a factory function');
     t.equal(requestIp.mw.length, 1, 'requestIp.mw expects 1 argument - options');

--- a/test/index.js
+++ b/test/index.js
@@ -226,3 +226,33 @@ test('req.connection.remoteAddress', function(t) {
     }
 });
 
+test('request-ip.mw -', function(t) {
+    t.plan(2);
+
+console.log(typeof requestIp.mw)
+    
+    t.equal(typeof requestIp.mw, 'function', 'requestIp.mw - should be a factory function');
+    t.equal(requestIp.mw.length, 1, 'requestIp.mw expects 1 argument - options');
+});
+
+test('request-ip.mw - used with no arguments', function(t) {
+    t.plan(2);
+    var mw = requestIp.mw();
+    t.ok(typeof mw == 'function' && mw.length == 3, 'returns a middleware');
+    
+    var mockReq = { headers : { 'x-forwarded-for' : "111.222.111.222"} };
+    mw( mockReq, null, function() { 
+        t.equal(mockReq.clientIp, "111.222.111.222", "when used - the middleware augments the request object with attribute 'clientIp'" );  
+    });
+});
+
+test('request-ip.mw - user code customizes augmented attribute name', function(t) {
+    t.plan(2);
+    var mw = requestIp.mw({ attributeName : "realIp" });
+    t.ok(typeof mw == 'function' && mw.length == 3, 'returns a middleware');
+    
+    var mockReq = { headers : { 'x-forwarded-for' : "111.222.111.222"} };
+    mw( mockReq, null, function() { 
+        t.equal(mockReq.realIp, "111.222.111.222", "when used - the middleware augments the request object with attribute name provided by user-code" );  
+    });
+});


### PR DESCRIPTION
lets not ask everybody to copy-paste this middleware code...

lets use a factory pattern to let users customise the middleware (and as a container for any future settings we may think to feature