### PR TITLE
Ignore 'unknown' ip addresses in X-Forwarded-For header

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function parseForwardedForAlt(forwardedForAlt) {
     // Sometimes IP addresses in this header can be 'unknown' (http://stackoverflow.com/a/11285650).
     // Therefore taking the left-most IP address that is not unknown
     for (var i = 0; i < forwardedIps.length; ++i) {
-        let ipAddress = forwardedIps[i].trim();
+        var ipAddress = forwardedIps[i].trim();
         if (ipAddress && ipAddress !== 'unknown') {
             return ipAddress;
         }


### PR DESCRIPTION
I ran into an issue when proxies do not reveal the original ip and set x-forwarded-for to 'unknown', instead. This commit fixed the problem for me and it shouldn't affect the cases that worked before.