### PR TITLE
Return once we find something and don't crash if req.headers is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,89 +22,71 @@ function getClientIp(req) {
 
     // workaround to get real client IP
     // most likely because our app will be behind a [reverse] proxy or load balancer
-    var clientIp = req.headers['x-client-ip'];
-    var forwardedForAlt = req.headers['x-forwarded-for'];
-    var realIp = req.headers['x-real-ip'];
-    
-    // more obsure ones below
-    var clusterClientIp = req.headers['x-cluster-client-ip'];
-    var forwardedAlt = req.headers['x-forwarded'];
-    var forwardedFor = req.headers['forwarded-for'];
-    var forwarded = req.headers['forwarded'];
-        
+    if (req.headers) {
+        if ((ipAddress = req.headers['x-client-ip'])) {
+            return ipAddress;
+        }
+
+        var forwardedForAlt = req.headers['x-forwarded-for'];
+        // (typically when your node app is behind a load-balancer (eg. AWS ELB) or proxy)
+        if (forwardedForAlt) {
+            // x-forwarded-for may return multiple IP addresses in the format:
+            // "client IP, proxy 1 IP, proxy 2 IP"
+            // Therefore, the right-most IP address is the IP address of the most recent proxy
+            // and the left-most IP address is the IP address of the originating client.
+            // source: http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html
+            var forwardedIps = forwardedForAlt.split(',');
+            return forwardedIps[0];
+        }
+
+        // (default nginx proxy/fcgi)
+        // alternative to x-forwarded-for, used by some proxies
+        if ((ipAddress = req.headers['x-real-ip'])) {
+            return ipAdress;
+        }
+
+        // (Rackspace LB and Riverbed's Stingray)
+        // http://www.rackspace.com/knowledge_center/article/controlling-access-to-linux-cloud-sites-based-on-the-client-ip-address
+        // https://splash.riverbed.com/docs/DOC-1926
+        if ((ipAddress = req.headers['x-cluster-client-ip'])) {
+            return ipAddress;
+        }
+
+        if ((ipAddress = req.headers['x-forwarded'])) {
+            return ipAddress;
+        }
+
+        if ((ipAddress = req.headers['forwarded-for'])) {
+            return ipAddress;
+        }
+
+        if ((ipAddress = req.headers['forwarded'])) {
+            return ipAddress;
+        }
+    }
+
     // remote address check
     var reqConnectionRemoteAddress = req.connection ? req.connection.remoteAddress : null;
     var reqSocketRemoteAddress = req.socket ? req.socket.remoteAddress : null;
     var reqConnectionSocketRemoteAddress = (req.connection && req.connection.socket) ? req.connection.socket.remoteAddress : null;
     var reqInfoRemoteAddress = req.info ? req.info.remoteAddress : null;
 
-    // x-client-ip
-    if (clientIp) {
-        ipAddress = clientIp;
-    }
-
-    // x-forwarded-for
-    // (typically when your node app is behind a load-balancer (eg. AWS ELB) or proxy)
-    else if (forwardedForAlt) {
-        // x-forwarded-for may return multiple IP addresses in the format: 
-        // "client IP, proxy 1 IP, proxy 2 IP" 
-        // Therefore, the right-most IP address is the IP address of the most recent proxy 
-        // and the left-most IP address is the IP address of the originating client.
-        // source: http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html
-        var forwardedIps = forwardedForAlt.split(',');
-        ipAddress = forwardedIps[0];
-    }
-
-    // x-real-ip 
-    // (default nginx proxy/fcgi)
-    else if (realIp) {
-        // alternative to x-forwarded-for, used by some proxies
-        ipAddress = realIp;
-    }
-
-    // x-cluster-client-ip 
-    // (Rackspace LB and Riverbed's Stingray)
-    // http://www.rackspace.com/knowledge_center/article/controlling-access-to-linux-cloud-sites-based-on-the-client-ip-address
-    // https://splash.riverbed.com/docs/DOC-1926
-    else if (clusterClientIp) {
-        ipAddress = clusterClientIp;
-    }
-
-    // x-forwarded
-    else if (forwardedAlt) {
-        ipAddress = forwardedAlt;
-    }
-
-    // forwarded-for
-    else if (forwardedFor) {
-        ipAddress = forwardedFor;
-    }
-
-    // forwarded
-    else if (forwarded) {
-        ipAddress = forwarded;
-    }
-
     // remote address checks
-    else if (reqConnectionRemoteAddress) {
-        ipAddress = reqConnectionRemoteAddress;
+    if ((ipAddress = req.connection && req.connection.remoteAddress)) {
+        return ipAddress;
     }
-    else if (reqSocketRemoteAddress) {
-        ipAddress = reqSocketRemoteAddress
+    if ((ipAddress = req.socket && req.socket.remoteAddress)) {
+        return ipAddress;
     }
-    else if (reqConnectionSocketRemoteAddress) {
-        ipAddress = reqConnectionSocketRemoteAddress
+    if ((ipAddress = req.connection && req.connection.socket && req.connection.socket.remoteAddress)) {
+        return ipAddress;
     }
-    else if (reqInfoRemoteAddress) {
-        ipAddress = reqInfoRemoteAddress
+    if ((ipAddress = req.info && req.info.remoteAddress)) {
+        return ipAddress;
     } 
 
     // return null if we cannot find an address
-    else {
-        ipAddress = null;
-    }
-    
-    return ipAddress;
+    return null;
 }
 
 /**


### PR DESCRIPTION
This address https://github.com/pbojinov/request-ip/issues/15 in that we return
once we find an address in the prescribed order. It only looks at as many elements as necessary.
This is definitely a micro-optimization but I think it helps clarity as well. This still retains the
comments as to where these headers come from.

This also address the possiblity of req.headers not existing. This might be an extreme edgecase but
it is one I have run into in my usage and having the fallback to not use the headers if they do not
exist within the library would help me.