### PR TITLE
Remove template string

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function getClientIpFromXForwardedFor(value) {
     }
 
     if (is.not.string(value)) {
-        throw new TypeError(`Expected a string, got "${typeof value}"`);
+        throw new TypeError('Expected a string, got "' + typeof value + '"');
     }
 
     // x-forwarded-for may return multiple IP addresses in the format:


### PR DESCRIPTION
Template strings are an ES6 feature, causes problems when running on a platform without ES6 support