### PR TITLE
redefine attribute getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,10 @@ function mw(options) {
 
     const attributeName = configuration.attributeName || 'clientIp';
     return (req, res, next) => {
-        req[attributeName] = getClientIp(req); // eslint-disable-line no-param-reassign
+        const ip = getClientIp(req);
+        Object.defineProperty(req, attributeName, {
+            get: () => ip,
+        });
         next();
     };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -430,6 +430,22 @@ test('request-ip.mw - user code customizes augmented attribute name', (t) => {
     });
 });
 
+test('request-ip.mw - attribute has getter by Object.defineProperty', (t) => {
+    t.plan(2);
+    const mw = requestIp.mw();
+    t.ok(typeof mw === 'function' && mw.length === 3, 'returns a middleware');
+
+    const mockReq = { headers: { 'x-forwarded-for': '111.222.111.222' } };
+    Object.defineProperty(mockReq, 'clientIp', {
+        enumerable: true,
+        configurable: true,
+        get: () => '1.2.3.4',
+    });
+    mw(mockReq, null, () => {
+        t.equal(mockReq.clientIp, '111.222.111.222', "when used - the middleware augments the request object with attribute 'clientIp'");
+    });
+});
+
 test('android request to AWS EBS app (x-forwarded-for)', (t) => {
     t.plan(1);
     // 172.x.x.x and 192.x.x.x. are considered "private IP subnets"


### PR DESCRIPTION
if getter for attribute exist, req[attributeName] = 'xx' will not make effect

mostly for express:
![image](https://user-images.githubusercontent.com/1747852/40596358-dbdce5b2-626c-11e8-9193-01452509b1aa.png)
