### PR TITLE
Get client ip when using AWS Api Gateway + Lambda.

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,11 @@ function getClientIp(req) {
         return req.info.remoteAddress;
     }
 
+    // AWS Api Gateway + Lambda
+    if (is.existy(req.requestContext) && is.existy(req.requestContext.identity) && is.ip(req.requestContext.identity.sourceIp)) {
+        return req.requestContext.identity.sourceIp;
+    }
+
     return null;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -395,6 +395,18 @@ test('getClientIp - req.info.remoteAddress', (t) => {
     t.equal(found, '50.18.192.250');
 });
 
+test('getClientIp - req.requestContext.identity.sourceIp', (t) => {
+    t.plan(1);
+    const found = requestIp.getClientIp({
+        requestContext: {
+            identity: {
+                sourceIp: '50.18.192.250',
+            },
+        },
+    });
+    t.equal(found, '50.18.192.250');
+});
+
 test('getClientIp - default', (t) => {
     t.plan(1);
     const found = requestIp.getClientIp({});


### PR DESCRIPTION
This is just an improvement, to retrieve the user's ip when working with Amazon API Gateway and Lambda.