### PR TITLE
fixed Cannot redefine property: clientIp error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -153,7 +153,8 @@ function mw(options) {
     Object.defineProperty(req, attributeName, {
       get: function get() {
         return ip;
-      }
+      },
+      configurable: true
     });
     next();
   };

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,7 @@ function mw(options) {
         const ip = getClientIp(req);
         Object.defineProperty(req, attributeName, {
             get: () => ip,
+            configurable: true
         });
         next();
     };


### PR DESCRIPTION
```
> TypeError: Cannot redefine property: clientIp
>     at Function.defineProperty (<anonymous>)
```

when using `app.use(requestIp.mw());`