### PR TITLE
Restructured to work with specific headers and orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "nyc --reporter=html --reporter=text --check-coverage --lines=100 --statements=100 tape ./test/index.js"
   },
   "dependencies": {
+    "extend": "^3.0.2",
     "is_js": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As per #26 I have restructured the code to allow for deciding which headers to use and what order they should be chosen in. It defaults back to how it works today so I do not believe any backward compatibility will be lost.