### PR TITLE
Fix npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   ],
   "files": [
-    "dist"
+    "lib"
   ],
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
`npm` package is missing the `lib` directory