### PR TITLE
add correct support for Forwarded header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,27 @@
 "use strict";
 
+function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
-
 var is = require('./is');
 
 function getClientIpFromXForwardedFor(value) {
   if (!is.existy(value)) {
     return null;
   }
-
   if (is.not.string(value)) {
     throw new TypeError("Expected a string, got \"".concat(_typeof(value), "\""));
   }
 
   var forwardedIps = value.split(',').map(function (e) {
     var ip = e.trim();
-
     if (ip.includes(':')) {
       var splitted = ip.split(':');
-
       if (splitted.length === 2) {
         return splitted[0];
       }
     }
-
     return ip;
   });
 
@@ -36,6 +34,40 @@ function getClientIpFromXForwardedFor(value) {
   return null;
 }
 
+function getClientIpFromForwarded(value) {
+  if (!is.existy(value)) {
+    return null;
+  }
+  if (is.not.string(value)) {
+    throw new TypeError("Expected a string, got \"".concat(_typeof(value), "\""));
+  }
+  var forwardedIps = value.split(';')[0];
+  var forwardedIp = null;
+  var _iterator = _createForOfIteratorHelper(forwardedIps.split(',')),
+    _step;
+  try {
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var forIp = _step.value;
+      var ip = forIp.split('=')[1].trim();
+      if (ip.includes(':')) {
+        var splitted = ip.split(':');
+        if (splitted.length === 2) {
+          ip = splitted[0];
+        }
+      }
+      if (is.ip(ip)) {
+        forwardedIp = ip;
+        break;
+      }
+    }
+  } catch (err) {
+    _iterator.e(err);
+  } finally {
+    _iterator.f();
+  }
+  return forwardedIp;
+}
+
 function getClientIp(req) {
   if (req.headers) {
     if (is.ip(req.headers['x-client-ip'])) {
@@ -43,7 +75,6 @@ function getClientIp(req) {
     }
 
     var xForwardedFor = getClientIpFromXForwardedFor(req.headers['x-forwarded-for']);
-
     if (is.ip(xForwardedFor)) {
       return xForwardedFor;
     }
@@ -67,17 +98,15 @@ function getClientIp(req) {
     if (is.ip(req.headers['x-cluster-client-ip'])) {
       return req.headers['x-cluster-client-ip'];
     }
-
     if (is.ip(req.headers['x-forwarded'])) {
       return req.headers['x-forwarded'];
     }
-
     if (is.ip(req.headers['forwarded-for'])) {
       return req.headers['forwarded-for'];
     }
-
-    if (is.ip(req.headers.forwarded)) {
-      return req.headers.forwarded;
+    var forwarded = getClientIpFromForwarded(req.headers.forwarded);
+    if (is.ip(forwarded)) {
+      return forwarded;
     }
 
     if (is.ip(req.headers['x-appengine-user-ip'])) {
@@ -89,16 +118,13 @@ function getClientIp(req) {
     if (is.ip(req.connection.remoteAddress)) {
       return req.connection.remoteAddress;
     }
-
     if (is.existy(req.connection.socket) && is.ip(req.connection.socket.remoteAddress)) {
       return req.connection.socket.remoteAddress;
     }
   }
-
   if (is.existy(req.socket) && is.ip(req.socket.remoteAddress)) {
     return req.socket.remoteAddress;
   }
-
   if (is.existy(req.info) && is.ip(req.info.remoteAddress)) {
     return req.info.remoteAddress;
   }
@@ -116,7 +142,6 @@ function getClientIp(req) {
   if (is.existy(req.raw)) {
     return getClientIp(req.raw);
   }
-
   return null;
 }
 
@@ -126,7 +151,6 @@ function mw(options) {
   if (is.not.object(configuration)) {
     throw new TypeError('Options must be an object!');
   }
-
   var attributeName = configuration.attributeName || 'clientIp';
   return function (req, res, next) {
     var ip = getClientIp(req);
@@ -139,9 +163,9 @@ function mw(options) {
     next();
   };
 }
-
 module.exports = {
   getClientIpFromXForwardedFor: getClientIpFromXForwardedFor,
+  getClientIpFromForwarded: getClientIpFromForwarded,
   getClientIp: getClientIp,
   mw: mw
 };

--- a/lib/is.js
+++ b/lib/is.js
@@ -26,7 +26,6 @@ function object(value) {
 function string(value) {
   return Object.prototype.toString.call(value) === '[object String]';
 }
-
 var is = {
   existy: existy,
   ip: ip,

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,29 @@ test('getClientIpFromXForwardedFor', (t) => {
     t.throws(() => requestIp.getClientIpFromXForwardedFor({}), TypeError);
 });
 
+test('getClientIpFromForwarded', (t) => {
+    t.plan(4);
+    t.equal(
+        requestIp.getClientIpFromForwarded(
+            'for=123.34.567.89,for=192.0.2.43;by=[APIGW_IP];host=apiid.execute-api.us-east-1.amazonaws.com;proto=https',
+        ),
+        '192.0.2.43',
+    );
+    t.equal(
+        requestIp.getClientIpFromForwarded(
+            'for=192.0.2.43:12345,for=93.186.30.120;by=[APIGW_IP];host=apiid.execute-api.us-east-1.amazonaws.com;proto=https',
+        ),
+        '192.0.2.43',
+    );
+    t.equal(
+        requestIp.getClientIpFromForwarded(
+            'for=unknown;host=public-api.example.org;proto=https',
+        ),
+        null,
+    );
+    t.throws(() => requestIp.getClientIpFromForwarded({}), TypeError);
+});
+
 test('x-client-ip', (t) => {
     t.plan(1);
     const options = {
@@ -185,6 +208,97 @@ test('x-forwarded-for with ipv4:port', (t) => {
                     .trim()
                     .split(':')[0];
                 t.equal(firstIp, found);
+                server.close();
+            }
+        });
+    });
+});
+
+test('forwarded', (t) => {
+    t.plan(1);
+    const options = {
+        url: '',
+        headers: {
+            forwarded:
+                'for=123.34.567.89,for=192.0.2.43;by=[APIGW_IP];host=apiid.execute-api.us-east-1.amazonaws.com;proto=https',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const lastIp = options.headers['forwarded']
+                    .split(';')[0]
+                    .split(',')[1]
+                    .split('=')[1]
+                    .trim();
+                t.equal(lastIp, found);
+                server.close();
+            }
+        });
+    });
+});
+
+test('forwarded with unknown ip', (t) => {
+    t.plan(1);
+    const options = {
+        url: '',
+        headers: {
+            forwarded:
+                'for=unknown,for=unknown,for=93.186.30.120;by=[APIGW_IP];host=apiid.execute-api.us-east-1.amazonaws.com;proto=https',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const lastIp = options.headers['forwarded']
+                    .split(';')[0]
+                    .split(',')[2]
+                    .split('=')[1]
+                    .trim();
+                t.equal(lastIp, found);
+                server.close();
+            }
+        });
+    });
+});
+
+test('forwarded with ipv4:port', (t) => {
+    t.plan(1);
+    const options = {
+        url: '',
+        headers: {
+            forwarded:
+                'for=93.186.30.120:8080;by=[APIGW_IP];host=apiid.execute-api.us-east-1.amazonaws.com;proto=https',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const lastIp = options.headers['forwarded']
+                    .split(';')[0]
+                    .split(',')[0]
+                    .split('=')[1]
+                    .split(':')[0]
+                    .trim();
+                t.equal(lastIp, found);
                 server.close();
             }
         });
@@ -323,30 +437,6 @@ test('forwarded-for', (t) => {
             if (!error && response.statusCode === 200) {
                 // make sure response ip is the same as the one we passed in
                 t.equal(options.headers['forwarded-for'], found);
-                server.close();
-            }
-        });
-    });
-});
-
-test('forwarded', (t) => {
-    t.plan(1);
-    const options = {
-        url: '',
-        headers: {
-            forwarded: '102.71.123.2',
-        },
-    };
-    // create new server for each test so we can easily close it after the test is done
-    // prevents tests from hanging and competing against closing a global server
-    const server = new ServerFactory();
-    server.listen(0, serverInfo.host);
-    server.on('listening', () => {
-        options.url = `http://${serverInfo.host}:${server.address().port}`;
-        request(options, (error, response, found) => {
-            if (!error && response.statusCode === 200) {
-                // make sure response ip is the same as the one we passed in
-                t.equal(options.headers.forwarded, found);
                 server.close();
             }
         });
@@ -582,11 +672,12 @@ test('Fastify (request.raw) found', (t) => {
     const found = requestIp.getClientIp({
         raw: {
             headers: {
-                forwarded: '91.203.163.199',
+                forwarded:
+                    'for=94.134.90.17;host=public-api.example.org;proto=https',
             },
         },
     });
-    t.equal(found, '91.203.163.199');
+    t.equal(found, '94.134.90.17');
 });
 
 test('Fastify (request.raw) not found', (t) => {


### PR DESCRIPTION
Resolves #70 

Sources

- https://tools.ietf.org/html/rfc7239
- https://medium.com/@lancers/amazon-api-gateway-explaining-http-proxy-in-http-api-3ea0afe6b03c#:~:text=Forwarded%20header,de%2Dfacto%2Dstandard
- https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/