### PR TITLE
Fixed for Fastify req.connection deprecation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,10 @@ function getClientIp(req) {
     }
   }
 
+  if (is.existy(req.socket) && is.ip(req.socket.remoteAddress)) {
+    return req.socket.remoteAddress;
+  }
+    
   if (is.existy(req.connection)) {
     if (is.ip(req.connection.remoteAddress)) {
       return req.connection.remoteAddress;
@@ -93,10 +97,6 @@ function getClientIp(req) {
     if (is.existy(req.connection.socket) && is.ip(req.connection.socket.remoteAddress)) {
       return req.connection.socket.remoteAddress;
     }
-  }
-
-  if (is.existy(req.socket) && is.ip(req.socket.remoteAddress)) {
-    return req.socket.remoteAddress;
   }
 
   if (is.existy(req.info) && is.ip(req.info.remoteAddress)) {


### PR DESCRIPTION
In Fastify, req.connection has been Deprecated in favor of req.socket. This affects all recent Fastify installs. The fix made so that nothing breaks but Fastify can pick its preferred `req.socket` option first without throwing any warnings at the developer.