### PR TITLE
Add support for K8S Ingress Header X-Original-Forwarded-For

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -190,6 +190,91 @@ test('x-forwarded-for with ipv4:port', (done) => {
     });
 });
 
+test('x-original-forwarded-for', (done) => {
+    expect.assertions(1);
+    const options = {
+        url: '',
+        headers: {
+            'x-original-forwarded-for': '129.78.138.66, 129.78.64.103, 129.78.64.105',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const lastIp = options.headers['x-original-forwarded-for']
+                    .split(',')[0]
+                    .trim();
+                expect(lastIp).toBe(found);
+                server.close();
+                done();
+            }
+        });
+    });
+});
+
+test('x-original-forwarded-for with unknown first ip', (done) => {
+    expect.assertions(1);
+    const options = {
+        url: '',
+        headers: {
+            'x-original-forwarded-for': 'unknown, 93.186.30.120',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const secondIp = options.headers['x-original-forwarded-for']
+                    .split(',')[1]
+                    .trim();
+                expect(secondIp).toBe(found);
+                server.close();
+                done();
+            }
+        });
+    });
+});
+
+test('x-original-forwarded-for with ipv4:port', (done) => {
+    expect.assertions(1);
+    const options = {
+        url: '',
+        headers: {
+            'x-original-forwarded-for': '93.186.30.120:12345',
+        },
+    };
+    // create new server for each test so we can easily close it after the test is done
+    // prevents tests from hanging and competing against closing a global server
+    const server = new ServerFactory();
+    server.listen(0, serverInfo.host);
+    server.on('listening', () => {
+        options.url = `http://${serverInfo.host}:${server.address().port}`;
+        request(options, (error, response, found) => {
+            if (!error && response.statusCode === 200) {
+                // make sure response ip is the same as the one we passed in
+                const firstIp = options.headers['x-original-forwarded-for']
+                    .split(',')[0]
+                    .trim()
+                    .split(':')[0];
+                expect(firstIp).toBe(found);
+                server.close();
+                done();
+            }
+        });
+    });
+});
+
 test('cf-connecting-ip', (done) => {
     expect.assertions(1);
     const options = {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "header",
     "X-Client-IP",
     "X-Forwarded-For",
+    "X-Original-Forwarded-For",
     "CF-Connecting-IP",
     "Fastly-Client-IP",
     "True-Client-IP",

--- a/src/index.js
+++ b/src/index.js
@@ -68,13 +68,21 @@ function getClientIp(req) {
             return xForwardedFor;
         }
 
+        // Kubernetes Ingress
+        const xOriginalForwardedFor = getClientIpFromXForwardedFor(
+            req.headers['x-original-forwarded-for'],
+        );
+        if (is.ip(xOriginalForwardedFor)) {
+            return xOriginalForwardedFor;
+        }
+
         // Cloudflare.
         // @see https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-
         // CF-Connecting-IP - applied to every request to the origin.
         if (is.ip(req.headers['cf-connecting-ip'])) {
             return req.headers['cf-connecting-ip'];
         }
-        
+
         // DigitalOcean.
         // @see https://www.digitalocean.com/community/questions/app-platform-client-ip
         // DO-Connecting-IP - applied to app platform servers behind a proxy.


### PR DESCRIPTION
Hey there! I've added support for the `X-Original-Forwarded-For` header, which is used by Kubernetes Ingress.

I've also put together a few tests to make sure everything works as expected:

* One test checks if we correctly pick the first IP when a list is passed.
* Another test makes sure we handle an 'unknown' IP gracefully and pick the next valid one.
* The last test ensures we correctly extract the IP when it comes with a port.

I believe these changes will make IP resolution in Kubernetes Ingress environments even better. Please have a look and let me know what you think.