### PR TITLE
add removal of start/end brackets around IPv6 addresses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,10 @@ function getClientIpFromXForwardedFor(value) {
   var forwardedIps = value.split(',').map(function (e) {
     var ip = e.trim();
 
+    if (ip.startsWith('[') && ip.endsWith(']')) {
+      ip = ip.substring(1, ip.length - 1);
+    }
+
     if (ip.includes(':')) {
       var splitted = ip.split(':');
 

--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
     "cloudflare",
     "Cf-Pseudo-IPv4"
   ],
-  "homepage": "https://github.com/pbojinov/request-ip",
+  "homepage": "https://github.com/NCI-CCR-OIT/request-ip",
   "bugs": {
-    "url": "https://github.com/pbojinov/request-ip/issues"
+    "url": "https://github.com/NCI-CCR-OIT/request-ip/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pbojinov/request-ip.git"
+    "url": "git+https://github.com/NCI-CCR-OIT/request-ip"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "license": "MIT",
   "author": "Petar Bojinov <petarbojinov+github@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "request-ip",
+  "name": "@nci-ccr-oit/request-ip",
   "version": "3.3.0",
   "description": "A small Node.js module to retrieve the request's IP address",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,11 @@ function getClientIpFromXForwardedFor(value) {
     // source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
     // Azure Web App's also adds a port for some reason, so we'll only use the first part (the IP)
     const forwardedIps = value.split(',').map((e) => {
-        const ip = e.trim();
+        let ip = e.trim();
+        if (ip.startsWith('[') && ip.endsWith(']')) {
+            // many proxies include brackets around ipv6 addresses, as per RFC7239; remove them
+            ip = ip.substring(1, ip.length - 1);
+        }
         if (ip.includes(':')) {
             const splitted = ip.split(':');
             // make sure we only use this if it's ipv4 (ip:port)


### PR DESCRIPTION
Many proxies (e.g., IIS) add start/end brackets around IPv6 addresses in the X-Forwarded-For header, which prevents request-ip from being able to see them there since that fails the is.ip IPv6 regex test; this removes them if they're there.

This uses functions that have been in Javascript since time immemorial (string.startsWith, string.endsWith, string.substring), and all tests continue to pass.