### PR TITLE
Note vulnerability to spoofing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # request-ip
 
-A tiny Node.js module for retrieving a request's IP address. 
+A tiny Node.js module for retrieving a request's IP address, for informational purposes only (not to be relied on for security).
 
 ![](https://nodei.co/npm/request-ip.png?downloads=true&cacheBust=3)
 
@@ -79,6 +79,15 @@ If an IP address cannot be found, it will return `null`.
 ## Samples Use Cases
 
 * Getting a user's IP for geolocation.
+
+## Security Warning
+This library is not to be relied upon for security purposes due to the risk of IP address spoofing by malicious clients, who could insert a false IP into a high-priority header.
+
+If you need to determine the IP securely, first determine how the clients will be connecting to your server:
+
+* Direct Connections: Use the TCP connection IP from the request object.
+* Through Proxies / Load Balancers: Identify the specific header used by your load balancer and parse that one only. Be aware of how your load balancer handles preexisting (spoofed) headers of that type. Commonly, the load balancer appends the client IP to the existing header, and therefore the legitimate IP is the rightmost entry. However if you have multiple chained proxies, each one will append to the header, and you'll either need to count leftwards from the right to find the true client IP, or set the later proxies in the chain to pass through the header unchanged.
+* Some of both: it will be challenging to do this securely. You will need to determine on a case-by-case basis whether a request has definitely come through your proxy (probably by matching the TCP IP against that of your proxies) and only rely on the header if it has.
 
 
 ## Running the Tests


### PR DESCRIPTION
Vulnerabilities related to IP spoofing have been known since 2017, but have never been fixed. Admittedly, fixing them would be difficult or impossible without radically altering the library and getting many complaints, which is why the one fix that was ever attempted was quickly reverted.

This library has many valid use cases, but it should be made clear that security is not one of them. Here is a draft of such a security warning. Feel free to suggest any edits.

See https://github.com/pbojinov/request-ip/issues/25#issuecomment-1819674645, and https://github.com/pbojinov/request-ip/issues/26